### PR TITLE
Add Support for Laravel 11 and drop Support for Laravel 8, 9, 10

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,23 +9,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
-        laravel: [11.*,10.*, 9.*]
+        php: [8.3,8.2]
+        laravel: [11.*]
         stability: [prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
-        exclude:
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 10.*
-            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,9 +10,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.1, 8.0]
-        laravel: [10.*, 9.*, 8.*]
+        laravel: [11.*,10.*, 9.*, 8.*]
         stability: [prefer-stable]
         include:
+          - laravel: 11.*
+            testbench: 9.*
           - laravel: 10.*
             testbench: 8.*
           - laravel: 9.*
@@ -20,8 +22,12 @@ jobs:
           - laravel: 8.*
             testbench: 6.*
         exclude:
+          - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
           - laravel: 10.*
-            php: 8.0        
+            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.3,8.2]
+        php: [8.3, 8.2]
         laravel: [11.*]
         stability: [prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.1, 8.0]
-        laravel: [11.*,10.*, 9.*, 8.*]
+        laravel: [11.*,10.*, 9.*]
         stability: [prefer-stable]
         include:
           - laravel: 11.*
@@ -19,8 +19,6 @@ jobs:
             testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
         exclude:
           - laravel: 11.*
             php: 8.0

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^8.35|^9.0|^10.0|^11.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "symfony/console": "^7.0"
     },
     "require-dev": {
         "ext-pcntl": "*",
         "brianium/paratest": "^6.2|^7.0",
         "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
-        "orchestra/testbench": "^6.16|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "pestphp/pest-plugin-laravel": "^1.3|^2.0",
         "phpunit/phpunit": "^9.5|^10|^11",
         "spatie/laravel-ray": "^1.17"

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
     },
     "require-dev": {
         "ext-pcntl": "*",
-        "brianium/paratest": "^6.2",
+        "brianium/paratest": "^6.2|^7.0",
         "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
         "orchestra/testbench": "^6.16|^7.0|^8.0|^9.0",
-        "pestphp/pest-plugin-laravel": "^1.3",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.0",
         "phpunit/phpunit": "^9.5|^10|^11",
         "spatie/laravel-ray": "^1.17"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^8.35|^9.0|^10.0"
+        "illuminate/contracts": "^8.35|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "ext-pcntl": "*",
         "brianium/paratest": "^6.2",
-        "nunomaduro/collision": "^5.3|^6.0",
-        "orchestra/testbench": "^6.16|^7.0|^8.0",
+        "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^6.16|^7.0|^8.0|^9.0",
         "pestphp/pest-plugin-laravel": "^1.3",
         "phpunit/phpunit": "^9.5",
         "spatie/laravel-ray": "^1.17"

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.4.3",
-        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^11.0",
         "symfony/console": "^7.0"
     },
     "require-dev": {
         "ext-pcntl": "*",
         "brianium/paratest": "^6.2|^7.0",
         "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^9.0",
         "pestphp/pest-plugin-laravel": "^1.3|^2.0",
         "phpunit/phpunit": "^9.5|^10|^11",
         "spatie/laravel-ray": "^1.17"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.4.3",
         "illuminate/contracts": "^11.0",
         "symfony/console": "^7.0"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
         "orchestra/testbench": "^6.16|^7.0|^8.0|^9.0",
         "pestphp/pest-plugin-laravel": "^1.3",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5|^10|^11",
         "spatie/laravel-ray": "^1.17"
     },
     "autoload": {

--- a/src/SignalAwareCommand.php
+++ b/src/SignalAwareCommand.php
@@ -14,13 +14,15 @@ abstract class SignalAwareCommand extends Command implements SignalableCommandIn
         return array_merge($this->autoDiscoverSignals(), $this->handlesSignals ?? []);
     }
 
-    public function handleSignal(int $signal): void
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
     {
         event(new SignalReceived($signal, $this));
 
         $this
             ->executeRegisteredSignalHandlers($signal)
             ->handleSignalMethodOnCommandClass($signal);
+
+        return $signal;
     }
 
     protected function executeRegisteredSignalHandlers(int $signal): self

--- a/tests/SignalTest.php
+++ b/tests/SignalTest.php
@@ -26,9 +26,11 @@ it('will fire the signal aware event', function () {
     /** @var \Spatie\SignalAwareCommand\SignalAwareCommand $command */
     $command = app()->make(TestCommand::class);
 
-    $command->handleSignal(SIGINT);
+    $result = $command->handleSignal(SIGINT);
 
     Event::assertDispatched(SignalReceived::class);
+
+    expect($result)->toEqual(SIGINT);
 });
 
 it('can clear registered handlers', function () {


### PR DESCRIPTION
This PR upgrades the package to support Laravel 11.

Laravel 11 will require `symfony/console:^7.0`, which had a breaking change in the `SignalableCommandInterface@handleSignal` method signature.

For easier maintenance, I've removed support for Laravel 8, 9 and 10 and PHP versions below 8.2.

---

I honestly have no clue what value `handleSignal` should return. I've opted to return the `$signal` in this PR, but please double check if this is the correct behaviour.

(While upgrading other packages to support Laravel 11 I noticed that this package doesn't support it either, so I thought I just send in a PR)